### PR TITLE
Update RPG_GearTab.cs to show list view by default for non-human pawns

### DIFF
--- a/Source/15/Sandy_Detailed_RPG_Inventory/RPG_GearTab.cs
+++ b/Source/15/Sandy_Detailed_RPG_Inventory/RPG_GearTab.cs
@@ -337,8 +337,9 @@ namespace Sandy_Detailed_RPG_Inventory
                 }
                 else
                 {
-                    TryDrawMassInfo(ref num, viewRect.width);
-                    TryDrawComfyTemperatureRange(ref num, viewRect.width);
+                    // TryDrawMassInfo(ref num, viewRect.width);
+                    // TryDrawComfyTemperatureRange(ref num, viewRect.width);
+                    DrawViewList(ref num, viewRect);
                 }
             }
             //inventory


### PR DESCRIPTION
Hello! First, I want to express my appreciation for your amazing work on this mod—thank you!

This pull request introduces a small patch to enhance the in-game experience when viewing non-human pawns (e.g., mechanoids). Currently, when list view is disabled, non-human pawns display an empty board by default. This often requires players like me to toggle list view manually to see their gear.

The proposed change automatically switches to list view for non-human pawns, streamlining the experience. I hope this aligns with your vision for the mod, but if it doesn’t fit your preferences, please feel free to reject it—no worries at all! I’m just aiming to contribute a minor improvement.

Thanks again for maintaining such a fantastic mod!